### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: Build VSIX
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ispc/vscode-ispc/security/code-scanning/1](https://github.com/ispc/vscode-ispc/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job (`build`), either location is acceptable, but the workflow level is more concise and future-proof. The minimal permissions required are:

- `contents: write` (needed for uploading release assets with `actions/upload-release-asset`)
- If only reading repository contents and uploading artifacts, `contents: read` would suffice, but since the workflow uploads release assets, `contents: write` is required.

Add the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: write
```

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
