### PR TITLE
Fix #121: Update engines.vscode to match @types/vscode 1.116.0

### DIFF
--- a/client-vscode/package.json
+++ b/client-vscode/package.json
@@ -11,7 +11,7 @@
     "icon": "images/ispc-icon.png",
     "publisher": "intel-corporation",
     "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.116.0"
     },
     "categories": [
         "Programming Languages",


### PR DESCRIPTION
Updates engines.vscode from ^1.110.0 to ^1.116.0 to match the @types/vscode version updated by Dependabot. The vsce packaging tool requires engines.vscode to be at least as high as the @types/vscode version.

Fixes failing: https://github.com/ispc/vscode-ispc/pull/121